### PR TITLE
overzicht voordat je bevestigd toegevoegd en algemenen voorwaarden

### DIFF
--- a/app/Http/Controllers/BookingController.php
+++ b/app/Http/Controllers/BookingController.php
@@ -94,10 +94,35 @@ class BookingController extends Controller
                     'name' => $request->name,
                     'email' => $request->email,
                     'opmerking' => $request->opmerking,
-                    // 'people' => $request->people,
                     'phone' => $request->phone,
                 ]);
 
+
+                $data = session()->only([
+                    'service',
+                    'date',
+                    'time_start',
+                    'time_end',
+                    'arrangement',
+                    'name',
+                    'email',
+                    'opmerking',
+                    'watertaxi_route_id',
+                    'people',
+                    'has_table',
+                    'phone',
+                    'price',
+                ]);
+
+                // Na invullen klantgegevens eerst een bevestigingsstap tonen
+                $step = 5;
+            }
+
+            elseif ($step == 5) {
+                // controleer dat algemene voorwaarden zijn geaccepteerd
+                $request->validate([
+                    'terms_accepted' => 'accepted',
+                ]);
 
                 $data = session()->only([
                     'service',
@@ -163,7 +188,8 @@ class BookingController extends Controller
 
                 Mail::to($booking->email)->send(new BookingConfirmationMail($booking));
 
-                $step = 5;
+                // Successtap na definitieve bevestiging
+                $step = 6;
             }
         }
 

--- a/resources/views/booking.blade.php
+++ b/resources/views/booking.blade.php
@@ -283,6 +283,14 @@
     border-color: #842029;
 }
 
+.terms-consent {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    text-align: left;
+}
+
 
     </style>
 </head>
@@ -686,7 +694,69 @@ document.addEventListener('DOMContentLoaded', function() {
     @endif
 @if($step==4)
 <div class="container py-5">
-    <h1 class="mb-4 text-center">Maak een Reservering</h1>
+    <h1 class="mb-4 text-center">Jouw gegevens</h1>
+
+    <div class="card shadow p-4">
+        <form action="{{ route('booking') }}" method="POST">
+            @csrf
+            <input type="hidden" name="step" value="4">
+
+            <div class="mb-3">
+                <label for="name" class="form-label">Naam</label>
+                <input type="text"
+                       class="form-control"
+                       id="name"
+                       name="name"
+                       value="{{ $data['name'] ?? '' }}"
+                       placeholder="Jouw naam"
+                       required>
+            </div>
+
+            <div class="mb-3">
+                <label for="email" class="form-label">E-mailadres</label>
+                <input type="email"
+                       class="form-control"
+                       id="email"
+                       name="email"
+                       value="{{ $data['email'] ?? '' }}"
+                       placeholder="jij@example.com"
+                       required>
+            </div>
+
+            <div class="mb-3">
+                <label for="phone" class="form-label">Telefoon nummer</label>
+                <input type="tel"
+                       class="form-control"
+                       id="phone"
+                       name="phone"
+                       value="{{ $data['phone'] ?? '' }}"
+                       placeholder="06 12345678"
+                       required>
+            </div>
+
+            <div class="mb-3">
+                <label for="opmerking" class="form-label">Opmerking</label>
+                <textarea class="form-control"
+                          id="opmerking"
+                          name="opmerking"
+                          rows="3"
+                          placeholder="Eventuele opmerkingen...">{{ $data['opmerking'] ?? '' }}</textarea>
+            </div>
+
+            @if(session('service') == 'Watertaxi')
+                <input type="hidden" name="watertaxi_route_id" value="{{ session('watertaxi_route_id') }}">
+            @endif
+
+            <button type="submit" class="booking-button">Ga naar overzicht</button>
+        </form>
+    </div>
+</div>
+@endif
+
+
+@if($step == 5)
+<div class="container py-5">
+    <h1 class="mb-4 text-center">Controleer je reservering</h1>
 
     <div class="card shadow p-4 mb-4">
         <h4 class="mb-3">Reserveringsoverzicht</h4>
@@ -763,65 +833,87 @@ document.addEventListener('DOMContentLoaded', function() {
         </table>
     </div>
 
+    <div class="card shadow p-4 mb-4">
+        <h4 class="mb-3">Jouw gegevens</h4>
+        <p><strong>Naam:</strong> {{ $data['name'] ?? '' }}</p>
+        <p><strong>E-mailadres:</strong> {{ $data['email'] ?? '' }}</p>
+        <p><strong>Telefoonnummer:</strong> {{ $data['phone'] ?? '' }}</p>
+        @if(!empty($data['opmerking']))
+            <p><strong>Opmerking:</strong> {{ $data['opmerking'] }}</p>
+        @endif
+    </div>
+
     <div class="card shadow p-4">
         <form action="{{ route('booking') }}" method="POST">
             @csrf
-            <input type="hidden" name="step" value="4">
-
-            <div class="mb-3">
-                <label for="name" class="form-label">Naam</label>
-                <input type="text" class="form-control" id="name" name="name" placeholder="Jouw naam" required>
+            <input type="hidden" name="step" value="5">
+            <div class="terms-consent mb-3">
+                <input class="form-check-input"
+                       type="checkbox"
+                       id="terms_accepted"
+                       name="terms_accepted"
+                       required>
+                <label class="form-check-label mb-0" for="terms_accepted">
+                    Ik ga akkoord met de
+                    <button type="button"
+                            id="open-terms"
+                            class="btn btn-link p-0 align-baseline">
+                        algemene voorwaarden
+                    </button>
+                </label>
             </div>
 
-            <div class="mb-3">
-                <label for="email" class="form-label">E-mailadres</label>
-                <input type="email" class="form-control" id="email" name="email" placeholder="jij@example.com" required>
-            </div>
-
-            <div class="mb-3">
-                <label for="phone" class="form-label">Telefoon nummer</label>
-                <input type="tel" class="form-control" id="phone" name="phone" placeholder="06 12345678" required>
-            </div>
-
-            <div class="mb-3">
-                <label for="opmerking" class="form-label">Opmerking</label>
-                <textarea class="form-control" id="opmerking" name="opmerking" rows="3" placeholder="Eventuele opmerkingen..."></textarea>
-            </div>
-
-            @if(session('service') == 'Watertaxi')
-                <input type="hidden" name="watertaxi_route_id" value="{{ session('watertaxi_route_id') }}">
-            @endif
-
-            <button type="submit" class="booking-button">Verstuur Booking</button>
+            <button type="submit" class="booking-button" id="confirm-btn" disabled>Bevestig reservering</button>
         </form>
     </div>
 </div>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const openTermsBtn = document.getElementById('open-terms');
+    const termsCheckbox = document.getElementById('terms_accepted');
+    const confirmBtn = document.getElementById('confirm-btn');
+
+    if (!openTermsBtn || !termsCheckbox || !confirmBtn) return;
+
+    openTermsBtn.addEventListener('click', function () {
+        // open algemene voorwaarden in nieuw tabblad
+        window.open('{{ route('terms') }}', '_blank');
+    });
+
+    termsCheckbox.addEventListener('change', function () {
+        confirmBtn.disabled = !termsCheckbox.checked;
+    });
+
+    // init state (als checkbox al aangevinkt is bij terugnavigeren)
+    confirmBtn.disabled = !termsCheckbox.checked;
+});
+</script>
 @endif
 
 
 
-    @if($step == 5)
-        <div class="container py-5">
+@if($step == 6)
+    <div class="container py-5">
 
-    <div class="card shadow p-4">
-        <h2>Boeking success</h2>
-        <p><strong>Service:</strong> {{ $data['service'] }}</p>
-        @if(!empty($data['departure']) && !empty($data['destination']))
-            <p><strong>Vertrekpunt:</strong> {{ $data['departure'] }}</p>
-            <p><strong>Bestemming:</strong> {{ $data['destination'] }}</p>
-        @endif
-        <p><strong>Datum:</strong> {{ $data['date'] }}</p>
-        @if(!empty($data['arrangement']))
-            <p><strong>Arrangement:</strong> {{ $data['arrangement'] }}</p>
-        @endif
+        <div class="card shadow p-4">
+            <h2>Boeking success</h2>
+            <p><strong>Service:</strong> {{ $data['service'] }}</p>
+            @if(!empty($data['departure']) && !empty($data['destination']))
+                <p><strong>Vertrekpunt:</strong> {{ $data['departure'] }}</p>
+                <p><strong>Bestemming:</strong> {{ $data['destination'] }}</p>
+            @endif
+            <p><strong>Datum:</strong> {{ $data['date'] }}</p>
+            @if(!empty($data['arrangement']))
+                <p><strong>Arrangement:</strong> {{ $data['arrangement'] }}</p>
+            @endif
 
-        <p><strong>Naam:</strong> {{ $data['name'] }}</p>
-        <p><strong>Email:</strong> {{ $data['email'] }}</p>
-        <p><strong>Opmerking:</strong>{{ $data['opmerking']  }}</p>
-        <p class="success"></p>
+            <p><strong>Naam:</strong> {{ $data['name'] }}</p>
+            <p><strong>Email:</strong> {{ $data['email'] }}</p>
+            <p><strong>Opmerking:</strong>{{ $data['opmerking']  }}</p>
+            <p class="success"></p>
+        </div>
     </div>
-    </div>
-    @endif
+@endif
 
 </body>
 </html>

--- a/resources/views/terms.blade.php
+++ b/resources/views/terms.blade.php
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Algemene voorwaarden</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+<div class="container py-5">
+    <h1 class="mb-4 text-center">Algemene voorwaarden</h1>
+
+    <div class="card shadow p-4">
+        <h4>1. Reserveringen</h4>
+        <p>
+            1.1. Een reservering is pas definitief nadat je een bevestiging per e-mail hebt ontvangen.<br>
+            1.2. De gegevens die je invult tijdens het reserveren moeten volledig en juist zijn.
+        </p>
+
+        <h4>2. Annuleringen en wijzigingen</h4>
+        <p>
+            2.1. Annuleren of wijzigen van een reservering kan tot 7 dagen voor vertrek, tenzij anders overeengekomen.<br>
+            2.2. Bij annulering korter dan 7 dagen voor vertrek kunnen kosten in rekening worden gebracht tot maximaal
+            100% van het reserveringsbedrag.
+        </p>
+
+        <h4>3. Betaling</h4>
+        <p>
+            3.1. Alle prijzen zijn inclusief btw, tenzij anders aangegeven.<br>
+            3.2. Betaling dient te gebeuren volgens de instructies in de factuur of bevestigingsmail.
+        </p>
+
+        <h4>4. Aansprakelijkheid</h4>
+        <p>
+            4.1. Deelname aan vaartochten en arrangementen is voor eigen risico.<br>
+            4.2. Wij zijn niet aansprakelijk voor verlies of schade aan persoonlijke eigendommen.
+        </p>
+
+        <h4>5. Huisregels aan boord</h4>
+        <p>
+            5.1. De aanwijzingen van de schipper en/of personeel dienen altijd te worden opgevolgd.<br>
+            5.2. Overmatig alcoholgebruik, agressief gedrag of gevaarlijk gedrag kan leiden tot het beëindigen van de tocht
+            zonder restitutie.
+        </p>
+
+        <h4>6. Weersomstandigheden</h4>
+        <p>
+            6.1. Bij extreme weersomstandigheden behouden wij ons het recht voor om de tocht te verplaatsen of te annuleren.<br>
+            6.2. In dat geval zoeken wij samen naar een passende oplossing, zoals een nieuwe datum.
+        </p>
+
+        <h4>7. Privacy</h4>
+        <p>
+            7.1. Wij gebruiken je persoonsgegevens uitsluitend voor het verwerken van de reservering en het verbeteren van
+            onze dienstverlening.<br>
+            7.2. Gegevens worden niet verkocht aan derden.
+        </p>
+
+        <h4>8. Slotbepalingen</h4>
+        <p>
+            8.1. Op alle overeenkomsten is het Nederlands recht van toepassing.<br>
+            8.2. Door je reservering te bevestigen ga je akkoord met deze algemene voorwaarden.
+        </p>
+
+    </div>
+</div>
+</body>
+</html>
+
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,9 @@ Route::match(['get', 'post'], '/booking', [BookingController::class, 'index'])->
 
 Route::view('/home', 'home')->name('home');
 
+// Algemene voorwaarden
+Route::view('/algemene-voorwaarden', 'terms')->name('terms');
+
 
 
 // Route::get('/admin/dashboard', [AdminController::class, 'calendar'])->middleware(AdminMiddleware::class);


### PR DESCRIPTION


**Toegevoegd:** een route en view voor de Algemene Voorwaarden, inclusief basisinhoud met secties (reserveringen, annuleringen, betalingen, aansprakelijkheid, huisregels, weersomstandigheden, privacy en slotbepalingen).

De boekingsflow is uitgebreid met een extra bevestigingsstap:

* **Stap 4** vraagt om de klantgegevens.
* **Stap 5** toont een volledig overzicht (service, datum/tijden, arrangement, prijs) en de ingevulde klantgegevens.
* In stap 5 is nu een checkbox toegevoegd: *“Ik ga akkoord met de algemene voorwaarden”*, inclusief een link naar de voorwaarden.
* De knop **“Bevestig reservering”** blijft gedeactiveerd totdat het vinkje is gezet.
* Server-side validatie (`terms_accepted => accepted`) voorkomt dat het vinkje wordt omzeild.
* De succespagina is verplaatst naar de nieuwe **stap 6**.

**Testing**

Handmatig de volledige wizard doorlopen voor zowel **Rondvaart** als **Watertaxi**:

* Navigeren door alle stappen werkt correct.
* De link naar de algemene voorwaarden opent in een nieuw tabblad; het aanvinken van de checkbox activeert de bevestigingsknop.
* Poging tot verzenden zonder vinkje resulteert in een correcte valideerfout.
* Na definitieve bevestiging verschijnt stap 6 met de samenvatting.